### PR TITLE
feat: symlinks and link helpers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,4 @@
+export const FIXTURE_TYPE_FILE_SYMBOL = Symbol("file");
+export const FIXTURE_TYPE_DIR_SYMBOL = Symbol("dir");
+export const FIXTURE_TYPE_LINK_SYMBOL = Symbol("testdir-link");
+export const FIXTURE_TYPE_SYMLINK_SYMBOL = Symbol("testdir-symlink");

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,2 @@
-export const FIXTURE_TYPE_FILE_SYMBOL = Symbol("file");
-export const FIXTURE_TYPE_DIR_SYMBOL = Symbol("dir");
 export const FIXTURE_TYPE_LINK_SYMBOL = Symbol("testdir-link");
 export const FIXTURE_TYPE_SYMLINK_SYMBOL = Symbol("testdir-symlink");

--- a/src/file-tree.ts
+++ b/src/file-tree.ts
@@ -1,6 +1,12 @@
 import { dirname, resolve } from "node:path";
 import { link, mkdir, symlink, writeFile } from "node:fs/promises";
-import { linkSync, mkdirSync, statSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  linkSync,
+  mkdirSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import type { DirectoryJSON } from "./types";
 import { isLink, isSymlink } from "./utils";
 
@@ -132,7 +138,7 @@ function isPrimitive(
 function isDir(abs: string, target: string) {
   try {
     return statSync(resolve(dirname(abs), target)).isDirectory();
-  // eslint-disable-next-line unused-imports/no-unused-vars
+    // eslint-disable-next-line unused-imports/no-unused-vars
   } catch (err) {
     return false;
   }

--- a/src/file-tree.ts
+++ b/src/file-tree.ts
@@ -2,7 +2,6 @@ import { dirname, resolve } from "node:path";
 import { link, mkdir, symlink, writeFile } from "node:fs/promises";
 import { linkSync, mkdirSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import type { DirectoryJSON } from "./types";
-import { FIXTURE_TYPE_LINK_SYMBOL } from "./constants";
 import { isLink, isSymlink } from "./utils";
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,4 @@
-export type {
-  DirectoryJSON,
-  DirectoryContent,
-} from "./types";
+export type { DirectoryJSON, DirectoryContent } from "./types";
 
 export {
   testdir,
@@ -10,11 +7,6 @@ export {
   DIR_REGEX,
   getDirNameFromTask,
 } from "./utils";
-export type {
-  TestdirOptions,
-} from "./utils";
+export type { TestdirOptions } from "./utils";
 
-export {
-  createFileTree,
-  createFileTreeSync,
-} from "./file-tree";
+export { createFileTree, createFileTreeSync } from "./file-tree";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,9 @@
-export type { DirectoryJSON, DirectoryContent, TestdirLink, TestdirSymlink } from "./types";
+export type {
+  DirectoryJSON,
+  DirectoryContent,
+  TestdirLink,
+  TestdirSymlink,
+} from "./types";
 export {
   testdir,
   testdirSync,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,14 @@
-export type { DirectoryJSON, DirectoryContent } from "./types";
-
+export type { DirectoryJSON, DirectoryContent, TestdirLink, TestdirSymlink } from "./types";
 export {
   testdir,
   testdirSync,
   BASE_DIR,
   DIR_REGEX,
   getDirNameFromTask,
+  isLink,
+  isSymlink,
+  link,
+  symlink,
 } from "./utils";
 export type { TestdirOptions } from "./utils";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,8 @@ export type DirectoryContent =
   | undefined
   | bigint
   | symbol
-  | TestdirSymlink;
+  | TestdirSymlink
+  | TestdirLink;
 
 export interface TestdirSymlink {
   [key: symbol]: typeof FIXTURE_TYPE_SYMLINK_SYMBOL;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,28 @@
-export type DirectoryContent = string | boolean | number | Uint8Array | null | undefined | bigint | symbol;
+import type {
+  FIXTURE_TYPE_LINK_SYMBOL,
+  FIXTURE_TYPE_SYMLINK_SYMBOL,
+} from "./constants";
+
+export type DirectoryContent =
+  | string
+  | boolean
+  | number
+  | Uint8Array
+  | null
+  | undefined
+  | bigint
+  | symbol
+  | TestdirSymlink;
+
+export interface TestdirSymlink {
+  [key: symbol]: typeof FIXTURE_TYPE_SYMLINK_SYMBOL;
+  path: string;
+}
+
+export interface TestdirLink {
+  [key: symbol]: typeof FIXTURE_TYPE_LINK_SYMBOL;
+  path: string;
+}
 
 export interface DirectoryJSON<T extends DirectoryContent = DirectoryContent> {
   [key: string]: T | DirectoryJSON<T>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,10 @@ import { type Task, onTestFinished } from "vitest";
 import { getCurrentTest } from "vitest/suite";
 import { createFileTree, createFileTreeSync } from "./file-tree";
 import type { DirectoryJSON, TestdirLink, TestdirSymlink } from "./types";
-import { FIXTURE_TYPE_LINK_SYMBOL, FIXTURE_TYPE_SYMLINK_SYMBOL } from "./constants";
+import {
+  FIXTURE_TYPE_LINK_SYMBOL,
+  FIXTURE_TYPE_SYMLINK_SYMBOL,
+} from "./constants";
 
 export const BASE_DIR = ".vitest-testdirs";
 
@@ -198,7 +201,12 @@ export function link(path: string): TestdirLink {
  * @returns {value is TestdirSymlink} The same value
  */
 export function isSymlink(value: unknown): value is TestdirSymlink {
-  return typeof value === "object" && value !== null && (value as TestdirSymlink)[FIXTURE_TYPE_SYMLINK_SYMBOL] === FIXTURE_TYPE_SYMLINK_SYMBOL;
+  return (
+    typeof value === "object"
+    && value !== null
+    && (value as TestdirSymlink)[FIXTURE_TYPE_SYMLINK_SYMBOL]
+    === FIXTURE_TYPE_SYMLINK_SYMBOL
+  );
 }
 
 /**
@@ -207,5 +215,10 @@ export function isSymlink(value: unknown): value is TestdirSymlink {
  * @returns {value is TestdirLink} The same value
  */
 export function isLink(value: unknown): value is TestdirLink {
-  return typeof value === "object" && value !== null && (value as TestdirLink)[FIXTURE_TYPE_LINK_SYMBOL] === FIXTURE_TYPE_LINK_SYMBOL;
+  return (
+    typeof value === "object"
+    && value !== null
+    && (value as TestdirLink)[FIXTURE_TYPE_LINK_SYMBOL]
+    === FIXTURE_TYPE_LINK_SYMBOL
+  );
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -168,6 +168,11 @@ export function getDirNameFromTask(task: Task): string {
   return dirName.replace(/-{2,}/g, "-").replace(/-+$/, "");
 }
 
+/**
+ * Create a symlink to a file or directory
+ * @param {string} path The path to link to
+ * @returns {TestdirSymlink} A TestdirSymlink object
+ */
 export function symlink(path: string): TestdirSymlink {
   return {
     [FIXTURE_TYPE_SYMLINK_SYMBOL]: FIXTURE_TYPE_SYMLINK_SYMBOL,
@@ -175,6 +180,11 @@ export function symlink(path: string): TestdirSymlink {
   };
 }
 
+/**
+ * Create a link to a file or directory
+ * @param {string} path The path to link to
+ * @returns {TestdirLink} A TestdirLink object
+ */
 export function link(path: string): TestdirLink {
   return {
     [FIXTURE_TYPE_LINK_SYMBOL]: FIXTURE_TYPE_LINK_SYMBOL,
@@ -182,10 +192,20 @@ export function link(path: string): TestdirLink {
   };
 }
 
+/**
+ * Check if value is a TestdirSymlink
+ * @param {unknown} value The value to check
+ * @returns {value is TestdirSymlink} The same value
+ */
 export function isSymlink(value: unknown): value is TestdirSymlink {
   return typeof value === "object" && value !== null && (value as TestdirSymlink)[FIXTURE_TYPE_SYMLINK_SYMBOL] === FIXTURE_TYPE_SYMLINK_SYMBOL;
 }
 
+/**
+ * Check if value is a TestdirLink
+ * @param value The value to check
+ * @returns {value is TestdirLink} The same value
+ */
 export function isLink(value: unknown): value is TestdirLink {
   return typeof value === "object" && value !== null && (value as TestdirLink)[FIXTURE_TYPE_LINK_SYMBOL] === FIXTURE_TYPE_LINK_SYMBOL;
 }

--- a/test/file-tree.test.ts
+++ b/test/file-tree.test.ts
@@ -116,11 +116,12 @@ describe("createFileTree", () => {
       "file1.txt": "Hello, world!",
       "dir1": {
         "file2.txt": "This is file 2",
+        "text.txt": "This is a text file",
         "dir2": {
           "file3.txt": "This is file 3",
         },
       },
-      "link1.txt": symlink("file1.txt"),
+      "link1.txt": symlink("dir1/text.txt"),
       "link2.txt": link("dir1/file2.txt"),
     };
 
@@ -150,14 +151,14 @@ describe("createFileTree", () => {
 
     expect(link2Content).toBe("This is file 2");
 
-    expect(fsMkdirSpy).toHaveBeenCalledTimes(5);
-    expect(fsWriteFileSpy).toHaveBeenCalledTimes(3);
+    expect(fsMkdirSpy).toHaveBeenCalledTimes(6);
+    expect(fsWriteFileSpy).toHaveBeenCalledTimes(4);
     expect(fsLinkSpy).toHaveBeenCalledTimes(1);
   });
 });
 
 describe("createFileTreeSync", () => {
-  it("should create a file tree at the specified path", async () => {
+  it("should create a file tree at the specified path", () => {
     const path = "./test";
     const files = {
       "file1.txt": "Hello, world!",
@@ -202,7 +203,7 @@ describe("createFileTreeSync", () => {
     expect(fsWriteFile).toHaveBeenCalledTimes(4);
   });
 
-  it("should create files using primitive types", async () => {
+  it("should create files using primitive types", () => {
     const path = "./test";
 
     const files = {
@@ -240,5 +241,51 @@ describe("createFileTreeSync", () => {
         expect(fileContent).toBe(String(content));
       }
     }
+  });
+
+  it("should be able to create symlinks", () => {
+    const path = "./test";
+    const files = {
+      "file1.txt": "Hello, world!",
+      "dir1": {
+        "file2.txt": "This is file 2",
+        "text.txt": "This is a text file",
+        "dir2": {
+          "file3.txt": "This is file 3",
+        },
+      },
+      "link1.txt": symlink("dir1/text.txt"),
+      "link2.txt": link("dir1/file2.txt"),
+    };
+
+    const fsMkdirSpy = vi.spyOn(fs, "mkdirSync");
+    const fsWriteFileSpy = vi.spyOn(fs, "writeFileSync");
+    const fsLinkSpy = vi.spyOn(fs, "linkSync");
+
+    createFileTreeSync(path, files);
+    const file1Content = readFileSync(resolve(path, "file1.txt"), "utf-8");
+    expect(file1Content).toBe("Hello, world!");
+
+    const file2Content = readFileSync(
+      resolve(path, "dir1/file2.txt"),
+      "utf-8",
+    );
+
+    expect(file2Content).toBe("This is file 2");
+
+    const file3Content = readFileSync(
+      resolve(path, "dir1/dir2/file3.txt"),
+      "utf-8",
+    );
+
+    expect(file3Content).toBe("This is file 3");
+
+    const link2Content = readFileSync(resolve(path, "link2.txt"), "utf-8");
+
+    expect(link2Content).toBe("This is file 2");
+
+    expect(fsMkdirSpy).toHaveBeenCalledTimes(6);
+    expect(fsWriteFileSpy).toHaveBeenCalledTimes(4);
+    expect(fsLinkSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/file-tree.test.ts
+++ b/test/file-tree.test.ts
@@ -266,10 +266,7 @@ describe("createFileTreeSync", () => {
     const file1Content = readFileSync(resolve(path, "file1.txt"), "utf-8");
     expect(file1Content).toBe("Hello, world!");
 
-    const file2Content = readFileSync(
-      resolve(path, "dir1/file2.txt"),
-      "utf-8",
-    );
+    const file2Content = readFileSync(resolve(path, "dir1/file2.txt"), "utf-8");
 
     expect(file2Content).toBe("This is file 2");
 

--- a/test/file-tree.test.ts
+++ b/test/file-tree.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 
 describe("createFileTree", () => {
   it("should create a file tree at the specified path", async () => {
-    const path = "./test";
+    const path = "./.vitest-testdirs/specified-path";
     const files = {
       "file1.txt": "Hello, world!",
       "this/is/nested.txt": "This is a file",
@@ -71,7 +71,7 @@ describe("createFileTree", () => {
   });
 
   it("should create files using primitive types", async () => {
-    const path = "./test";
+    const path = "./.vitest-testdirs/primitive-types";
 
     const files = {
       "file1.txt": "Hello, world!",
@@ -111,7 +111,7 @@ describe("createFileTree", () => {
   });
 
   it("should be able to create symlinks", async () => {
-    const path = "./test";
+    const path = "./.vitest-testdirs/with-links";
     const files = {
       "file1.txt": "Hello, world!",
       "dir1": {
@@ -159,7 +159,7 @@ describe("createFileTree", () => {
 
 describe("createFileTreeSync", () => {
   it("should create a file tree at the specified path", () => {
-    const path = "./test";
+    const path = "./.vitest-testdirs/specified-path-sync";
     const files = {
       "file1.txt": "Hello, world!",
       "this/is/nested.txt": "This is a file",
@@ -204,7 +204,7 @@ describe("createFileTreeSync", () => {
   });
 
   it("should create files using primitive types", () => {
-    const path = "./test";
+    const path = "./.vitest-testdirs/primitive-types-sync";
 
     const files = {
       "file1.txt": "Hello, world!",
@@ -244,7 +244,7 @@ describe("createFileTreeSync", () => {
   });
 
   it("should be able to create symlinks", () => {
-    const path = "./test";
+    const path = "./.vitest-testdirs/with-links-sync";
     const files = {
       "file1.txt": "Hello, world!",
       "dir1": {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -15,21 +15,21 @@ import { getCurrentTest } from "vitest/suite";
 import { getDirNameFromTask, isLink, isSymlink, link, symlink, testdir, testdirSync } from "../src/utils";
 import { FIXTURE_TYPE_LINK_SYMBOL, FIXTURE_TYPE_SYMLINK_SYMBOL } from "../src/constants";
 
-// vi.mock("node:fs/promises", async () => {
-//   const memfs: { fs: typeof fs } = await vi.importActual("memfs");
+vi.mock("node:fs/promises", async () => {
+  const memfs: { fs: typeof fs } = await vi.importActual("memfs");
 
-//   return memfs.fs.promises;
-// });
+  return memfs.fs.promises;
+});
 
-// vi.mock("node:fs", async () => {
-//   const memfs: { fs: typeof fs } = await vi.importActual("memfs");
+vi.mock("node:fs", async () => {
+  const memfs: { fs: typeof fs } = await vi.importActual("memfs");
 
-//   return memfs.fs;
-// });
+  return memfs.fs;
+});
 
-// afterEach(() => {
-//   vi.clearAllMocks();
-// });
+afterEach(() => {
+  vi.clearAllMocks();
+});
 
 describe("getDirNameFromTask", () => {
   it("should return the correct directory name for a task using 'getCurrentTest'", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -133,7 +133,7 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toContainEqual([
+    expect(await readdir(dirname)).toContain([
       "file1.txt",
       "file2.txt",
       "subdir",
@@ -223,7 +223,7 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toContainEqual([
+    expect(await readdir(dirname)).toContain([
       "file1.txt",
       "file2.txt",
       "link4.txt",
@@ -264,7 +264,7 @@ describe("testdirSync", () => {
 
     const dirname = testdirSync(files);
 
-    expect(readdirSync(dirname)).toEqual(["file1.txt", "file2.txt", "subdir"]);
+    expect(readdirSync(dirname)).toContain(["file1.txt", "file2.txt", "subdir"]);
     expect(readdirSync(join(dirname, "subdir"))).toEqual(["file3.txt"]);
     expect(readFileSync(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(readFileSync(join(dirname, "file2.txt"), "utf8")).toBe("content2");
@@ -348,7 +348,7 @@ describe("testdirSync", () => {
 
     const dirname = testdirSync(files);
 
-    expect(readdirSync(dirname)).toContainEqual([
+    expect(readdirSync(dirname)).toContain([
       "file1.txt",
       "file2.txt",
       "link4.txt",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -15,21 +15,21 @@ import { getCurrentTest } from "vitest/suite";
 import { getDirNameFromTask, isLink, isSymlink, link, symlink, testdir, testdirSync } from "../src/utils";
 import { FIXTURE_TYPE_LINK_SYMBOL, FIXTURE_TYPE_SYMLINK_SYMBOL } from "../src/constants";
 
-vi.mock("node:fs/promises", async () => {
-  const memfs: { fs: typeof fs } = await vi.importActual("memfs");
+// vi.mock("node:fs/promises", async () => {
+//   const memfs: { fs: typeof fs } = await vi.importActual("memfs");
 
-  return memfs.fs.promises;
-});
+//   return memfs.fs.promises;
+// });
 
-vi.mock("node:fs", async () => {
-  const memfs: { fs: typeof fs } = await vi.importActual("memfs");
+// vi.mock("node:fs", async () => {
+//   const memfs: { fs: typeof fs } = await vi.importActual("memfs");
 
-  return memfs.fs;
-});
+//   return memfs.fs;
+// });
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
+// afterEach(() => {
+//   vi.clearAllMocks();
+// });
 
 describe("getDirNameFromTask", () => {
   it("should return the correct directory name for a task using 'getCurrentTest'", () => {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -133,7 +133,7 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toEqual([
+    expect(await readdir(dirname)).toContainEqual([
       "file1.txt",
       "file2.txt",
       "subdir",
@@ -223,7 +223,7 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toEqual([
+    expect(await readdir(dirname)).toContainEqual([
       "file1.txt",
       "file2.txt",
       "link4.txt",
@@ -348,7 +348,7 @@ describe("testdirSync", () => {
 
     const dirname = testdirSync(files);
 
-    expect(readdirSync(dirname)).toEqual([
+    expect(readdirSync(dirname)).toContainEqual([
       "file1.txt",
       "file2.txt",
       "link4.txt",

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,6 +1,12 @@
 import { lstat, readFile, readdir, readlink, stat } from "node:fs/promises";
 import { join, normalize } from "node:path";
-import { lstatSync, readFileSync, readdirSync, readlinkSync, statSync } from "node:fs";
+import {
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  readlinkSync,
+  statSync,
+} from "node:fs";
 import type { fs } from "memfs";
 import {
   type Task,
@@ -12,8 +18,19 @@ import {
   vi,
 } from "vitest";
 import { getCurrentTest } from "vitest/suite";
-import { getDirNameFromTask, isLink, isSymlink, link, symlink, testdir, testdirSync } from "../src/utils";
-import { FIXTURE_TYPE_LINK_SYMBOL, FIXTURE_TYPE_SYMLINK_SYMBOL } from "../src/constants";
+import {
+  getDirNameFromTask,
+  isLink,
+  isSymlink,
+  link,
+  symlink,
+  testdir,
+  testdirSync,
+} from "../src/utils";
+import {
+  FIXTURE_TYPE_LINK_SYMBOL,
+  FIXTURE_TYPE_SYMLINK_SYMBOL,
+} from "../src/constants";
 
 vi.mock("node:fs/promises", async () => {
   const memfs: { fs: typeof fs } = await vi.importActual("memfs");
@@ -133,11 +150,9 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toContain([
-      "file1.txt",
-      "file2.txt",
-      "subdir",
-    ]);
+    expect(await readdir(dirname)).toEqual(
+      expect.arrayContaining(["file1.txt", "file2.txt", "subdir"]),
+    );
     expect(await readdir(join(dirname, "subdir"))).toEqual(["file3.txt"]);
     expect(await readFile(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(await readFile(join(dirname, "file2.txt"), "utf8")).toBe("content2");
@@ -223,32 +238,48 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toContain([
-      "file1.txt",
-      "file2.txt",
-      "link4.txt",
-      "link5.txt",
-      "subdir",
-    ]);
+    expect(await readdir(dirname)).toEqual(
+      expect.arrayContaining([
+        "file1.txt",
+        "file2.txt",
+        "link4.txt",
+        "link5.txt",
+        "subdir",
+      ]),
+    );
 
-    expect(await readdir(join(dirname, "subdir"))).toEqual(["file3.txt", "file4.txt", "file5.txt"]);
+    expect(await readdir(join(dirname, "subdir"))).toEqual([
+      "file3.txt",
+      "file4.txt",
+      "file5.txt",
+    ]);
     expect(await readFile(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(await readFile(join(dirname, "file2.txt"), "utf8")).toBe("content2");
     expect(await readFile(join(dirname, "link4.txt"), "utf8")).toBe("content1");
     expect((await stat(join(dirname, "link4.txt"))).isFile()).toBe(true);
 
     expect(await readlink(join(dirname, "link5.txt"), "utf8")).toBeDefined();
-    expect((await lstat(join(dirname, "link5.txt"))).isSymbolicLink()).toBe(true);
+    expect((await lstat(join(dirname, "link5.txt"))).isSymbolicLink()).toBe(
+      true,
+    );
 
     expect(await readFile(join(dirname, "subdir", "file3.txt"), "utf8")).toBe(
       "content3",
     );
 
-    expect(await readFile(join(dirname, "subdir", "file4.txt"), "utf8")).toBe("content1");
-    expect((await stat(join(dirname, "subdir", "file4.txt"))).isFile()).toBe(true);
+    expect(await readFile(join(dirname, "subdir", "file4.txt"), "utf8")).toBe(
+      "content1",
+    );
+    expect((await stat(join(dirname, "subdir", "file4.txt"))).isFile()).toBe(
+      true,
+    );
 
-    expect(await readlink(join(dirname, "subdir", "file5.txt"), "utf8")).toBeDefined();
-    expect((await lstat(join(dirname, "subdir", "file5.txt"))).isSymbolicLink()).toBe(true);
+    expect(
+      await readlink(join(dirname, "subdir", "file5.txt"), "utf8"),
+    ).toBeDefined();
+    expect(
+      (await lstat(join(dirname, "subdir", "file5.txt"))).isSymbolicLink(),
+    ).toBe(true);
   });
 });
 
@@ -264,7 +295,9 @@ describe("testdirSync", () => {
 
     const dirname = testdirSync(files);
 
-    expect(readdirSync(dirname)).toContain(["file1.txt", "file2.txt", "subdir"]);
+    expect(readdirSync(dirname)).toEqual(
+      expect.arrayContaining(["file1.txt", "file2.txt", "subdir"]),
+    );
     expect(readdirSync(join(dirname, "subdir"))).toEqual(["file3.txt"]);
     expect(readFileSync(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(readFileSync(join(dirname, "file2.txt"), "utf8")).toBe("content2");
@@ -348,15 +381,21 @@ describe("testdirSync", () => {
 
     const dirname = testdirSync(files);
 
-    expect(readdirSync(dirname)).toContain([
-      "file1.txt",
-      "file2.txt",
-      "link4.txt",
-      "link5.txt",
-      "subdir",
-    ]);
+    expect(readdirSync(dirname)).toEqual(
+      expect.arrayContaining([
+        "file1.txt",
+        "file2.txt",
+        "link4.txt",
+        "link5.txt",
+        "subdir",
+      ]),
+    );
 
-    expect(readdirSync(join(dirname, "subdir"))).toEqual(["file3.txt", "file4.txt", "file5.txt"]);
+    expect(readdirSync(join(dirname, "subdir"))).toEqual([
+      "file3.txt",
+      "file4.txt",
+      "file5.txt",
+    ]);
     expect(readFileSync(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(readFileSync(join(dirname, "file2.txt"), "utf8")).toBe("content2");
     expect(readFileSync(join(dirname, "link4.txt"), "utf8")).toBe("content1");
@@ -369,11 +408,17 @@ describe("testdirSync", () => {
       "content3",
     );
 
-    expect(readFileSync(join(dirname, "subdir", "file4.txt"), "utf8")).toBe("content1");
+    expect(readFileSync(join(dirname, "subdir", "file4.txt"), "utf8")).toBe(
+      "content1",
+    );
     expect(statSync(join(dirname, "subdir", "file4.txt")).isFile()).toBe(true);
 
-    expect(readlinkSync(join(dirname, "subdir", "file5.txt"), "utf8")).toBeDefined();
-    expect(lstatSync(join(dirname, "subdir", "file5.txt")).isSymbolicLink()).toBe(true);
+    expect(
+      readlinkSync(join(dirname, "subdir", "file5.txt"), "utf8"),
+    ).toBeDefined();
+    expect(
+      lstatSync(join(dirname, "subdir", "file5.txt")).isSymbolicLink(),
+    ).toBe(true);
   });
 });
 

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,7 +2,15 @@ import { readFile, readdir } from "node:fs/promises";
 import { join, normalize } from "node:path";
 import { readFileSync, readdirSync } from "node:fs";
 import type { fs } from "memfs";
-import { type Task, afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import {
+  type Task,
+  afterEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+} from "vitest";
 import { getCurrentTest } from "vitest/suite";
 import { getDirNameFromTask, testdir, testdirSync } from "../src/utils";
 
@@ -26,7 +34,9 @@ describe("getDirNameFromTask", () => {
   it("should return the correct directory name for a task using 'getCurrentTest'", () => {
     const dirName = getDirNameFromTask(getCurrentTest()!);
 
-    expect(dirName).toBe("vitest-utils-getDirNameFromTask-should-return-the-correct-directory-name-for-a-task-using-getCurrentTest");
+    expect(dirName).toBe(
+      "vitest-utils-getDirNameFromTask-should-return-the-correct-directory-name-for-a-task-using-getCurrentTest",
+    );
   });
 
   it("should use 'unnamed' as the file name if the task does not have a file name", () => {
@@ -38,7 +48,9 @@ describe("getDirNameFromTask", () => {
 
     const dirName = getDirNameFromTask(task);
 
-    expect(dirName).toBe("vitest-unnamed-utils-should-use-unnamed-as-the-file-name-if-the-task-does-not-have-a-file-name");
+    expect(dirName).toBe(
+      "vitest-unnamed-utils-should-use-unnamed-as-the-file-name-if-the-task-does-not-have-a-file-name",
+    );
   });
 
   it("should include suite name in the directory name", () => {
@@ -50,7 +62,9 @@ describe("getDirNameFromTask", () => {
 
     const dirName = getDirNameFromTask(task);
 
-    expect(dirName).toBe("vitest-unnamed-utils-should-include-suite-name-in-the-directory-name");
+    expect(dirName).toBe(
+      "vitest-unnamed-utils-should-include-suite-name-in-the-directory-name",
+    );
   });
 
   it("should remove '.test.ts' from the file name", () => {
@@ -61,7 +75,9 @@ describe("getDirNameFromTask", () => {
 
     const dirName = getDirNameFromTask(task);
 
-    expect(dirName).toBe("vitest-utils-should-remove-test-ts-from-the-file-name");
+    expect(dirName).toBe(
+      "vitest-utils-should-remove-test-ts-from-the-file-name",
+    );
   });
 
   it("should replace non-alphanumeric characters with '-'", () => {
@@ -72,7 +88,9 @@ describe("getDirNameFromTask", () => {
 
     const dirName = getDirNameFromTask(task);
 
-    expect(dirName).toBe("vitest-utils-should-replace-non-alphanumeric-characters-with");
+    expect(dirName).toBe(
+      "vitest-utils-should-replace-non-alphanumeric-characters-with",
+    );
   });
 
   it("should replace trailing hyphens with nothing", () => {
@@ -83,7 +101,9 @@ describe("getDirNameFromTask", () => {
 
     const dirName = getDirNameFromTask(task);
 
-    expect(dirName).toBe("vitest-utils-should-replace-trailing-hyphens-with-nothing");
+    expect(dirName).toBe(
+      "vitest-utils-should-replace-trailing-hyphens-with-nothing",
+    );
   });
 
   it("should replace multiple hyphens with a single hyphen", () => {
@@ -94,7 +114,9 @@ describe("getDirNameFromTask", () => {
 
     const dirName = getDirNameFromTask(task);
 
-    expect(dirName).toBe("vitest-utils-should-replace-multiple-hyphens-with-a-single-hyphen");
+    expect(dirName).toBe(
+      "vitest-utils-should-replace-multiple-hyphens-with-a-single-hyphen",
+    );
   });
 });
 
@@ -110,11 +132,17 @@ describe("testdir", () => {
 
     const dirname = await testdir(files);
 
-    expect(await readdir(dirname)).toEqual(["file1.txt", "file2.txt", "subdir"]);
+    expect(await readdir(dirname)).toEqual([
+      "file1.txt",
+      "file2.txt",
+      "subdir",
+    ]);
     expect(await readdir(join(dirname, "subdir"))).toEqual(["file3.txt"]);
     expect(await readFile(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(await readFile(join(dirname, "file2.txt"), "utf8")).toBe("content2");
-    expect(await readFile(join(dirname, "subdir", "file3.txt"), "utf8")).toBe("content3");
+    expect(await readFile(join(dirname, "subdir", "file3.txt"), "utf8")).toBe(
+      "content3",
+    );
   });
 
   it("should generate a directory name based on the test name if dirname is not provided", async () => {
@@ -123,7 +151,11 @@ describe("testdir", () => {
     };
 
     const dirname = await testdir(files);
-    expect(dirname).toBe(normalize(".vitest-testdirs/vitest-utils-testdir-should-generate-a-directory-name-based-on-the-test-name-if-dirname-is-not-provided"));
+    expect(dirname).toBe(
+      normalize(
+        ".vitest-testdirs/vitest-utils-testdir-should-generate-a-directory-name-based-on-the-test-name-if-dirname-is-not-provided",
+      ),
+    );
   });
 
   it("should generate a directory name based on the provided dirname", async () => {
@@ -166,9 +198,13 @@ describe("testdir", () => {
       "file.txt": "content",
     };
 
-    await expect(testdir(files, {
-      dirname: "../testdir",
-    })).rejects.toThrowError("The directory name must start with '.vitest-testdirs'");
+    await expect(
+      testdir(files, {
+        dirname: "../testdir",
+      }),
+    ).rejects.toThrowError(
+      "The directory name must start with '.vitest-testdirs'",
+    );
   });
 });
 
@@ -188,7 +224,9 @@ describe("testdirSync", () => {
     expect(readdirSync(join(dirname, "subdir"))).toEqual(["file3.txt"]);
     expect(readFileSync(join(dirname, "file1.txt"), "utf8")).toBe("content1");
     expect(readFileSync(join(dirname, "file2.txt"), "utf8")).toBe("content2");
-    expect(readFileSync(join(dirname, "subdir", "file3.txt"), "utf8")).toBe("content3");
+    expect(readFileSync(join(dirname, "subdir", "file3.txt"), "utf8")).toBe(
+      "content3",
+    );
   });
 
   it("should generate a directory name based on the test name if dirname is not provided", () => {
@@ -197,7 +235,11 @@ describe("testdirSync", () => {
     };
 
     const dirname = testdirSync(files);
-    expect(dirname).toBe(normalize(".vitest-testdirs/vitest-utils-testdirSync-should-generate-a-directory-name-based-on-the-test-name-if-dirname-is-not-provided"));
+    expect(dirname).toBe(
+      normalize(
+        ".vitest-testdirs/vitest-utils-testdirSync-should-generate-a-directory-name-based-on-the-test-name-if-dirname-is-not-provided",
+      ),
+    );
   });
 
   it("should generate a directory name based on the provided dirname", () => {
@@ -240,8 +282,10 @@ describe("testdirSync", () => {
       "file.txt": "content",
     };
 
-    expect(() => testdirSync(files, {
-      dirname: "../testdir",
-    })).toThrowError("The directory name must start with '.vitest-testdirs'");
+    expect(() =>
+      testdirSync(files, {
+        dirname: "../testdir",
+      }),
+    ).toThrowError("The directory name must start with '.vitest-testdirs'");
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,11 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: [
-    "./src/index.ts",
-    "./src/file-tree.ts",
-    "./src/utils.ts",
-  ],
+  entry: ["./src/index.ts", "./src/file-tree.ts", "./src/utils.ts"],
   format: ["cjs", "esm"],
   clean: true,
   dts: true,


### PR DESCRIPTION
This PR makes it possible to create softlinks and hardlinks using the `symlink` or `link` function exposed from utils and index.