### PR TITLE
feat: add snapshot functionality to testdir

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "vitest": ">=3.0.0 <4.0.0"
   },
   "dependencies": {
-    "testdirs": "^3.1.1"
+    "testdirs": "^3.2.0"
   },
   "devDependencies": {
     "@luxass/eslint-config": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       testdirs:
-        specifier: ^3.1.1
-        version: 3.1.1
+        specifier: ^3.2.0
+        version: 3.2.0
     devDependencies:
       '@luxass/eslint-config':
         specifier: ^5.3.0
@@ -1976,8 +1976,8 @@ packages:
     resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
     engines: {node: '>=18'}
 
-  testdirs@3.1.1:
-    resolution: {integrity: sha512-roM2UJUe6FvEdySN2GdzV6k08H5aIQMn60LhAOwL/V6k5hozt8pkOBdEQhEfek6OuIxEtNc3sx1afZKf/V3dVg==}
+  testdirs@3.2.0:
+    resolution: {integrity: sha512-+4t632ZA7L588ZlIu5lZbaX8GkqtqCdtEybEIaQWn9ZblH/q5cXSxcsEvgHkIIiTTZ43GLcSwizbErJz1SfJqg==}
     engines: {node: '>=20'}
 
   tinybench@2.9.0:
@@ -4352,7 +4352,7 @@ snapshots:
       glob: 10.4.5
       minimatch: 9.0.5
 
-  testdirs@3.1.1: {}
+  testdirs@3.2.0: {}
 
   tinybench@2.9.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,8 @@
  * ```
  */
 
-import type { FromFileSystemOptions } from "testdirs";
+import type { DirectoryJSON, FromFileSystemOptions } from "testdirs";
+import { readdir } from "node:fs/promises";
 import { relative, resolve } from "node:path";
 import { fromFileSystem, testdir as originalTestdir } from "testdirs";
 import { createCustomTestdir } from "testdirs/factory";
@@ -181,6 +182,37 @@ export const testdir = createCustomTestdir(async ({ files, fixturePath, options 
       }
 
       return internalGenerateDirname(dirname);
+    },
+    snapshots: async (files: DirectoryJSON, options: TestdirOptions) => {
+      const dir = await testdir(files, options);
+      return {
+        path: dir,
+        snapshot: async (): Promise<string> => {
+          // read entire directory
+          const directory = await readdir(dir, {
+            withFileTypes: true,
+            recursive: true,
+          });
+
+          let tree = "";
+
+          const buildTree = (dir: string, depth: number) => {
+            const indent = "  ".repeat(depth);
+            for (const entry of directory) {
+              if (entry.isDirectory()) {
+                tree += `${indent}├── ${entry.name}/\n`;
+                buildTree(`${dir}/${entry.name}`, depth + 1);
+              } else {
+                tree += `${indent}├── ${entry.name}\n`;
+              }
+            }
+          };
+
+          buildTree(dir, 0);
+
+          return tree;
+        },
+      };
     },
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,8 +16,7 @@
  * ```
  */
 
-import type { DirectoryJSON, FromFileSystemOptions } from "testdirs";
-import { readdir } from "node:fs/promises";
+import type { FromFileSystemOptions } from "testdirs";
 import { relative, resolve } from "node:path";
 import { fromFileSystem, testdir as originalTestdir } from "testdirs";
 import { createCustomTestdir } from "testdirs/factory";
@@ -42,6 +41,7 @@ export {
 } from "./constants";
 
 export {
+  captureSnapshot,
   hasMetadata,
   isLink,
   isPrimitive,
@@ -182,37 +182,6 @@ export const testdir = createCustomTestdir(async ({ files, fixturePath, options 
       }
 
       return internalGenerateDirname(dirname);
-    },
-    snapshots: async (files: DirectoryJSON, options: TestdirOptions) => {
-      const dir = await testdir(files, options);
-      return {
-        path: dir,
-        snapshot: async (): Promise<string> => {
-          // read entire directory
-          const directory = await readdir(dir, {
-            withFileTypes: true,
-            recursive: true,
-          });
-
-          let tree = "";
-
-          const buildTree = (dir: string, depth: number) => {
-            const indent = "  ".repeat(depth);
-            for (const entry of directory) {
-              if (entry.isDirectory()) {
-                tree += `${indent}├── ${entry.name}/\n`;
-                buildTree(`${dir}/${entry.name}`, depth + 1);
-              } else {
-                tree += `${indent}├── ${entry.name}\n`;
-              }
-            }
-          };
-
-          buildTree(dir, 0);
-
-          return tree;
-        },
-      };
     },
   },
 });


### PR DESCRIPTION
- Introduced a new `snapshots` method to the `testdir` function.
- This method reads the entire directory structure and returns a formatted tree representation.
- Utilizes `readdir` from `node:fs/promises` for asynchronous directory reading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added captureSnapshot to the public API, enabling direct import and use.
- Chores
  - Updated a dependency to v3.2.0 for compatibility and maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->