### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/luxass/vitest-testdirs/security/code-scanning/2](https://github.com/luxass/vitest-testdirs/security/code-scanning/2)

**General approach:**  
Explicitly define the `permissions` key to restrict the GITHUB_TOKEN access to the minimum required scope—in this context, only `contents: read`. This can be defined at the workflow root (applies to all jobs unless overridden) or individually per job. Since both jobs ("build" and "test") seem to only require read access, defining it at the root keeps the file DRY and consistent.

**Detail:**  
- Add a `permissions: { contents: read }` block (YAML) at the top level of the workflow, just after the `name:` and before `on:`.  
- No additional imports, methods, or definitions are required, as this is a YAML metadata change.

**Specifics:**  
- Edit the beginning of `.github/workflows/ci.yml`.
- Insert these lines:
```yaml
permissions:
  contents: read
```
- Ensure the indentation and formatting matches the rest of the YAML file structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration configuration to explicitly use read-only repository permissions, improving security via least-privilege access.
  * No changes to workflow triggers, jobs, or steps; build, test, and deployment behavior remain unchanged.
  * Enhances pipeline security posture without affecting application functionality or user experience.
  * No action required from users or contributors; existing workflows continue to run as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->